### PR TITLE
Improve feed UI and add liked art panel

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -27,21 +27,41 @@
   text-transform: uppercase;
 }
 
-.art-feed__refresh {
+.art-feed__header-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.art-feed__icon-button {
   border: 1px solid rgba(245, 245, 245, 0.24);
   background: rgba(40, 40, 40, 0.6);
   color: inherit;
-  border-radius: 999px;
-  padding: 0.5rem 1rem;
-  transition: background 0.2s ease, transform 0.2s ease;
+  border-radius: 50%;
+  width: 2.85rem;
+  height: 2.85rem;
+  display: grid;
+  place-items: center;
+  transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
 }
 
-.art-feed__refresh:hover {
-  background: rgba(60, 60, 60, 0.8);
+.art-feed__icon-button svg {
+  width: 1.35rem;
+  height: 1.35rem;
+  fill: currentColor;
 }
 
-.art-feed__refresh:active {
-  transform: scale(0.97);
+.art-feed__icon-button:hover {
+  background: rgba(60, 60, 60, 0.85);
+}
+
+.art-feed__icon-button:active {
+  transform: scale(0.96);
+}
+
+.art-feed__icon-button.is-active {
+  background: rgba(227, 73, 91, 0.9);
+  border-color: rgba(255, 255, 255, 0.4);
 }
 
 .art-feed__scroller {
@@ -66,15 +86,17 @@
 .art-card {
   position: relative;
   display: flex;
-  align-items: center;
+  align-items: stretch;
   justify-content: center;
-  min-height: calc(100vh - 5.5rem);
-  margin: 0 auto 1.5rem;
-  width: clamp(280px, 100%, 820px);
+  height: calc(100vh - 5.5rem);
+  width: min(92vw, 520px);
+  max-width: 520px;
+  margin: 0 auto 2.4rem;
   scroll-snap-align: start;
-  border-radius: 24px;
+  border-radius: 32px;
   overflow: hidden;
-  background: #090909;
+  background: #060606;
+  box-shadow: 0 28px 60px rgba(0, 0, 0, 0.65);
 }
 
 .art-card__media {
@@ -83,40 +105,43 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.12), rgba(0, 0, 0, 0.85));
+  background: linear-gradient(180deg, rgba(18, 18, 18, 0.2) 0%, rgba(2, 2, 2, 0.9) 100%);
 }
 
 .art-card__image {
   width: 100%;
   height: 100%;
-  object-fit: contain;
-  background-color: #000;
+  object-fit: cover;
+  object-position: center;
+  background-color: #050505;
+  transform: scale(1.02);
 }
 
 .art-card__info {
   position: absolute;
   inset: auto 0 0 0;
-  padding: 1.8rem 2rem 2.2rem;
-  background: linear-gradient(180deg, rgba(5, 5, 5, 0) 0%, rgba(5, 5, 5, 0.88) 40%, rgba(5, 5, 5, 0.95) 100%);
+  padding: 2rem 3.6rem 2.6rem 2rem;
+  background: linear-gradient(180deg, rgba(5, 5, 5, 0) 0%, rgba(5, 5, 5, 0.88) 45%, rgba(5, 5, 5, 0.96) 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: calc(100% - 5.5rem);
 }
 
 .art-card__title {
-  font-size: 1.75rem;
+  font-size: clamp(1.35rem, 2.8vw, 1.7rem);
   font-weight: 700;
-  margin-bottom: 0.35rem;
   text-shadow: 0 2px 12px rgba(0, 0, 0, 0.9);
 }
 
 .art-card__artist {
-  font-size: 1rem;
-  opacity: 0.82;
-  margin-bottom: 0.75rem;
+  font-size: clamp(0.95rem, 2vw, 1.05rem);
+  opacity: 0.8;
 }
 
 .art-card__description {
   font-size: 0.95rem;
-  line-height: 1.5;
-  margin-bottom: 0.75rem;
+  line-height: 1.55;
   color: rgba(245, 245, 245, 0.9);
 }
 
@@ -136,65 +161,260 @@
   list-style: none;
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
-  font-size: 0.8rem;
-  opacity: 0.7;
+  gap: 0.45rem;
+  font-size: 0.78rem;
+  opacity: 0.75;
 }
 
 .art-card__meta li {
   padding: 0.3rem 0.7rem;
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.14);
 }
 
 .art-card__actions {
   position: absolute;
-  right: 1.4rem;
-  bottom: 9rem;
+  top: 50%;
+  right: 1.35rem;
+  transform: translateY(-50%);
   display: flex;
   flex-direction: column;
-  gap: 1.3rem;
+  gap: 1.15rem;
   align-items: center;
 }
 
 .art-card__action-button {
-  width: 3.5rem;
-  height: 3.5rem;
+  width: 3.25rem;
+  height: 3.25rem;
   border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  background: rgba(0, 0, 0, 0.55);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(0, 0, 0, 0.58);
   color: inherit;
   display: grid;
   place-items: center;
   font-size: 1.6rem;
-  transition: transform 0.2s ease, background 0.2s ease, border 0.2s ease;
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.35);
+  transition: transform 0.2s ease, background 0.2s ease, border 0.2s ease, box-shadow 0.2s ease;
 }
 
 .art-card__action-button:hover {
-  transform: scale(1.05);
-  background: rgba(255, 255, 255, 0.12);
+  transform: translateY(-2px) scale(1.03);
+  background: rgba(255, 255, 255, 0.14);
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.45);
 }
 
 .art-card__action-button:active {
-  transform: scale(0.97);
+  transform: scale(0.95);
 }
 
 .art-card__action-button.is-active {
   background: rgba(227, 73, 91, 0.9);
-  border-color: rgba(255, 255, 255, 0.4);
+  border-color: rgba(255, 255, 255, 0.45);
 }
 
 .art-card__action-svg {
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 1.45rem;
+  height: 1.45rem;
   fill: currentColor;
 }
 
 .art-card__share-feedback {
-  font-size: 0.75rem;
-  background: rgba(0, 0, 0, 0.7);
-  padding: 0.25rem 0.5rem;
+  margin-top: 0.35rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(0, 0, 0, 0.65);
+  padding: 0.3rem 0.65rem;
   border-radius: 999px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+.liked-panel__backdrop {
+  position: fixed;
+  inset: 0;
+  border: none;
+  background: rgba(5, 5, 5, 0.55);
+  backdrop-filter: blur(4px);
+  z-index: 25;
+}
+
+.liked-panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: min(420px, 100vw);
+  transform: translateX(100%);
+  transition: transform 0.35s ease;
+  z-index: 30;
+  pointer-events: none;
+}
+
+.liked-panel.is-open {
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
+.liked-panel__container {
+  height: 100%;
+  background: rgba(12, 12, 12, 0.96);
+  backdrop-filter: blur(12px);
+  box-shadow: -28px 0 48px rgba(0, 0, 0, 0.6);
+  padding: 1.75rem 2rem 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  overflow: hidden;
+}
+
+.liked-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.liked-panel__eyebrow {
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  opacity: 0.6;
+}
+
+.liked-panel__heading {
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.liked-panel__close {
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(20, 20, 20, 0.6);
+  color: inherit;
+  border-radius: 50%;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: grid;
+  place-items: center;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.liked-panel__close:hover {
+  background: rgba(40, 40, 40, 0.75);
+  transform: scale(1.03);
+}
+
+.liked-panel__close:active {
+  transform: scale(0.95);
+}
+
+.liked-panel__close svg {
+  width: 1.15rem;
+  height: 1.15rem;
+  fill: currentColor;
+}
+
+.liked-panel__list {
+  flex: 1;
+  list-style: none;
+  margin: 0;
+  padding: 0 0.35rem 0 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.liked-panel__item {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 1rem;
+  align-items: stretch;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.liked-panel__thumb {
+  position: relative;
+  aspect-ratio: 3 / 4;
+  overflow: hidden;
+  background: rgba(10, 10, 10, 0.6);
+}
+
+.liked-panel__thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.liked-panel__thumb-like {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: rgba(0, 0, 0, 0.55);
+  display: grid;
+  place-items: center;
+  color: inherit;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.liked-panel__thumb-like:hover {
+  transform: scale(1.05);
+  background: rgba(227, 73, 91, 0.85);
+}
+
+.liked-panel__thumb-like:active {
+  transform: scale(0.94);
+}
+
+.liked-panel__thumb-like svg {
+  width: 1.1rem;
+  height: 1.1rem;
+  fill: currentColor;
+}
+
+.liked-panel__details {
+  padding: 1rem 1rem 1rem 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 0.35rem;
+}
+
+.liked-panel__title {
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.liked-panel__artist {
+  font-size: 0.85rem;
+  opacity: 0.7;
+}
+
+.liked-panel__empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  gap: 0.75rem;
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  border-radius: 20px;
+  padding: 1.5rem;
+  color: rgba(245, 245, 245, 0.75);
+}
+
+.liked-panel__hint {
+  font-size: 0.8rem;
+  opacity: 0.6;
 }
 
 .art-feed__status {
@@ -243,31 +463,38 @@
 
 @media (max-width: 768px) {
   .art-feed__header {
-    padding: 0.75rem 1.1rem;
+    padding: 0.75rem 1rem;
   }
 
   .art-feed__brand {
     font-size: 1.2rem;
   }
 
-  .art-feed__refresh {
-    padding: 0.4rem 0.8rem;
-    font-size: 0.85rem;
+  .art-feed__icon-button {
+    width: 2.5rem;
+    height: 2.5rem;
+  }
+
+  .art-feed__icon-button svg {
+    width: 1.1rem;
+    height: 1.1rem;
   }
 
   .art-card {
     width: 100%;
     border-radius: 0;
     margin-bottom: 0;
-    min-height: calc(100vh - 4.5rem);
+    height: calc(100vh - 4.75rem);
+    box-shadow: none;
   }
 
   .art-card__info {
-    padding: 1.2rem 1.25rem 1.8rem;
+    padding: 1.5rem 3.2rem 2.4rem 1.4rem;
+    max-width: calc(100% - 4.8rem);
   }
 
   .art-card__title {
-    font-size: 1.45rem;
+    font-size: clamp(1.3rem, 5vw, 1.6rem);
   }
 
   .art-card__artist {
@@ -279,19 +506,30 @@
   }
 
   .art-card__actions {
-    right: 0.75rem;
-    bottom: 7rem;
+    right: 1rem;
+    gap: 1rem;
   }
 
   .art-card__action-button {
     width: 3rem;
     height: 3rem;
-    font-size: 1.4rem;
   }
 
   .art-card__action-svg {
-    width: 1.35rem;
-    height: 1.35rem;
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  .liked-panel {
+    width: min(85vw, 360px);
+  }
+
+  .liked-panel__container {
+    padding: 1.5rem 1.6rem 2rem;
+  }
+
+  .liked-panel__item {
+    grid-template-columns: 110px 1fr;
   }
 }
 
@@ -301,7 +539,28 @@
   }
 
   .art-card__action-button,
-  .art-feed__refresh {
+  .art-feed__icon-button,
+  .liked-panel,
+  .liked-panel__thumb-like,
+  .liked-panel__close {
     transition: none;
+  }
+}
+
+@media (max-width: 540px) {
+  .art-card__info {
+    padding: 1.35rem 3rem 2.2rem 1.2rem;
+  }
+
+  .liked-panel {
+    width: 100%;
+  }
+
+  .liked-panel__container {
+    padding: 1.4rem 1.25rem 2rem;
+  }
+
+  .liked-panel__item {
+    grid-template-columns: minmax(96px, 40%) 1fr;
   }
 }

--- a/src/components/ArtCard.tsx
+++ b/src/components/ArtCard.tsx
@@ -26,8 +26,8 @@ const ShareIcon = () => (
     aria-hidden="true"
     focusable="false"
   >
-    <path d="M14 2l7 7-1.41 1.41L15 6.83V16h-2V6.83L8.41 10.41 7 9z" />
-    <path d="M5 20h14v-6h2v8H3v-8h2z" />
+    <path d="M12 3l5.05 5.05-1.41 1.41L13 6.83V17h-2V6.83L8.36 9.46 6.95 8.05z" />
+    <path d="M5 19h14v-2H5z" />
   </svg>
 );
 

--- a/src/components/LikedArtPanel.tsx
+++ b/src/components/LikedArtPanel.tsx
@@ -1,0 +1,166 @@
+import { useCallback, useEffect, useRef } from "react";
+import { observer } from "mobx-react-lite";
+import type { ArtPiece } from "../types/art";
+import { useLikedArt } from "../hooks/useLikedArt";
+import { useLikedArtCollection } from "../hooks/useLikedArtCollection";
+
+interface LikedArtPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const CloseIcon = () => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+    <path
+      d="M18.3 5.71a1 1 0 0 0-1.41 0L12 10.59 7.11 5.7A1 1 0 0 0 5.7 7.11L10.59 12l-4.9 4.89a1 1 0 1 0 1.41 1.41L12 13.41l4.89 4.89a1 1 0 0 0 1.41-1.41L13.41 12l4.89-4.89a1 1 0 0 0 0-1.4z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
+const HeartFilledIcon = () => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+    <path
+      d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 6 4 4 6.5 4c1.54 0 3.04 0.99 3.57 2.36h0.21C10.81 4.99 12.31 4 13.85 4 16.34 4 18.35 6 18.35 8.5c0 3.78-3.4 6.86-8.55 11.54z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
+function LikedArtListItem({ piece }: { piece: ArtPiece }) {
+  const { toggleLike } = useLikedArt(piece.id);
+
+  return (
+    <li className="liked-panel__item">
+      <div className="liked-panel__thumb">
+        <img src={piece.imageUrl} alt={`${piece.title} by ${piece.artist}`} loading="lazy" />
+        <button
+          type="button"
+          className="liked-panel__thumb-like"
+          aria-label={`Remove ${piece.title} from liked art`}
+          onClick={toggleLike}
+        >
+          <HeartFilledIcon />
+        </button>
+      </div>
+      <div className="liked-panel__details">
+        <p className="liked-panel__title">{piece.title}</p>
+        <p className="liked-panel__artist">{piece.artist}</p>
+      </div>
+    </li>
+  );
+}
+
+export const LikedArtPanel = observer(function LikedArtPanel({ isOpen, onClose }: LikedArtPanelProps) {
+  const { likedPieces, likedIds } = useLikedArtCollection();
+  const panelRef = useRef<HTMLDivElement | null>(null);
+
+  const handleSwipeClose = useCallback(
+    (event: TouchEvent) => {
+      const panel = panelRef.current;
+      if (!panel) {
+        return;
+      }
+
+      const touchStart = event.touches[0];
+      if (!touchStart) {
+        return;
+      }
+
+      const startX = touchStart.clientX;
+      const startY = touchStart.clientY;
+
+      const handleTouchEnd = (endEvent: TouchEvent) => {
+        const touchEnd = endEvent.changedTouches[0];
+        const deltaX = touchEnd.clientX - startX;
+        const deltaY = Math.abs(touchEnd.clientY - startY);
+
+        if (deltaX > 70 && deltaY < 60) {
+          onClose();
+        }
+
+        panel.removeEventListener("touchend", handleTouchEnd);
+      };
+
+      panel.addEventListener("touchend", handleTouchEnd, { once: true });
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    const panel = panelRef.current;
+
+    if (!isOpen || !panel) {
+      return;
+    }
+
+    panel.addEventListener("touchstart", handleSwipeClose);
+
+    return () => {
+      panel.removeEventListener("touchstart", handleSwipeClose);
+    };
+  }, [handleSwipeClose, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  const missingCount = likedIds.length - likedPieces.length;
+
+  return (
+    <aside
+      className={`liked-panel ${isOpen ? "is-open" : ""}`.trim()}
+      role="dialog"
+      aria-modal="true"
+      aria-hidden={!isOpen}
+      aria-live="polite"
+    >
+      <div className="liked-panel__container" ref={panelRef}>
+        <header className="liked-panel__header">
+          <div>
+            <p className="liked-panel__eyebrow">Your collection</p>
+            <h2 className="liked-panel__heading">Liked art</h2>
+          </div>
+          <button type="button" className="liked-panel__close" onClick={onClose} aria-label="Close liked art">
+            <CloseIcon />
+          </button>
+        </header>
+
+        {likedPieces.length > 0 ? (
+          <ul className="liked-panel__list">
+            {likedPieces.map((piece) => (
+              <LikedArtListItem key={piece.id} piece={piece} />
+            ))}
+          </ul>
+        ) : (
+          <div className="liked-panel__empty">
+            <p>No liked artworks yet.</p>
+            <p>Tap the heart on pieces you love to build your collection.</p>
+          </div>
+        )}
+
+        {missingCount > 0 && (
+          <p className="liked-panel__hint">
+            {missingCount === 1
+              ? "One liked artwork isn\'t loaded in this feed yet. Keep scrolling to see it."
+              : `${missingCount} liked artworks aren't loaded in this feed yet. Keep scrolling to see them.`}
+          </p>
+        )}
+      </div>
+    </aside>
+  );
+});

--- a/src/hooks/useLikedArtCollection.ts
+++ b/src/hooks/useLikedArtCollection.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import artImagesStore from "../stores/ArtImagesStore";
+import type { ArtPiece } from "../types/art";
+import {
+  LIKED_ART_STORAGE_EVENT,
+  LIKED_ART_STORAGE_KEY,
+  readLikedSet,
+} from "../utils/likedArtStorage";
+
+export function useLikedArtCollection() {
+  const [likedIds, setLikedIds] = useState<number[]>(() => Array.from(readLikedSet()));
+
+  useEffect(() => {
+    const syncFromStorage = () => {
+      setLikedIds(Array.from(readLikedSet()));
+    };
+
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === LIKED_ART_STORAGE_KEY) {
+        syncFromStorage();
+      }
+    };
+
+    window.addEventListener(LIKED_ART_STORAGE_EVENT, syncFromStorage);
+    window.addEventListener("storage", handleStorage);
+
+    return () => {
+      window.removeEventListener(LIKED_ART_STORAGE_EVENT, syncFromStorage);
+      window.removeEventListener("storage", handleStorage);
+    };
+  }, []);
+
+  const piecesById = new Map(artImagesStore.artPieces.map((piece) => [piece.id, piece]));
+  const likedPieces = likedIds
+    .map((id) => piecesById.get(id) ?? null)
+    .filter((piece): piece is ArtPiece => Boolean(piece));
+
+  return {
+    likedPieces,
+    likedIds,
+  };
+}

--- a/src/pages/FeedPage.tsx
+++ b/src/pages/FeedPage.tsx
@@ -1,17 +1,98 @@
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { observer } from "mobx-react";
 import artImagesStore from "../stores/ArtImagesStore";
 import { ArtCard } from "../components/ArtCard";
 import { useInfiniteScroll } from "../hooks/useInfiniteScroll";
+import { LikedArtPanel } from "../components/LikedArtPanel";
+
+const RefreshIcon = () => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+    <path
+      d="M17.65 6.35A7.95 7.95 0 0 0 12 4a8 8 0 0 0-7.45 5H2l3.89 3.89h0.07L10 9H6.26A6 6 0 0 1 12 6a6 6 0 0 1 4.24 10.24l1.42 1.42A8 8 0 0 0 17.65 6.35Z"
+      fill="currentColor"
+    />
+    <path d="M12 20a8 8 0 0 0 7.45-5H22l-3.89-3.89h-0.07L14 15h3.74A6 6 0 0 1 12 18a6 6 0 0 1-4.24-10.24L6.34 6.34A8 8 0 0 0 12 20Z" fill="currentColor" />
+  </svg>
+);
+
+const CollectionIcon = () => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+    <path
+      d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3 9.24 3 10.91 3.81 12 5.09 13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54Z"
+      fill="currentColor"
+    />
+  </svg>
+);
 
 const FeedPage = observer(function FeedPage() {
   const { artPieces, isLoading, isInitialLoad, hasMore, error } = artImagesStore;
+  const [isLikedPanelOpen, setIsLikedPanelOpen] = useState(false);
+  const scrollerRef = useRef<HTMLDivElement | null>(null);
+
+  const closeLikedPanel = useCallback(() => setIsLikedPanelOpen(false), []);
+  const toggleLikedPanel = useCallback(
+    () => setIsLikedPanelOpen((previous) => !previous),
+    [],
+  );
+
+  const togglePanelFromSwipe = useCallback(
+    (direction: "left" | "right") => {
+      if (direction === "left" && !isLikedPanelOpen) {
+        setIsLikedPanelOpen(true);
+      } else if (direction === "right" && isLikedPanelOpen) {
+        setIsLikedPanelOpen(false);
+      }
+    },
+    [isLikedPanelOpen],
+  );
 
   useEffect(() => {
     if (!artImagesStore.artPieces.length) {
       artImagesStore.fetchNextPage();
     }
   }, []);
+
+  useEffect(() => {
+    const scroller = scrollerRef.current;
+
+    if (!scroller) {
+      return;
+    }
+
+    let touchStartX: number | null = null;
+    let touchStartY: number | null = null;
+
+    const handleTouchStart = (event: TouchEvent) => {
+      const touch = event.touches[0];
+      touchStartX = touch.clientX;
+      touchStartY = touch.clientY;
+    };
+
+    const handleTouchEnd = (event: TouchEvent) => {
+      if (touchStartX === null || touchStartY === null) {
+        return;
+      }
+
+      const touch = event.changedTouches[0];
+      const deltaX = touch.clientX - touchStartX;
+      const deltaY = Math.abs(touch.clientY - touchStartY);
+
+      if (Math.abs(deltaX) > 70 && deltaY < 60) {
+        togglePanelFromSwipe(deltaX < 0 ? "left" : "right");
+      }
+
+      touchStartX = null;
+      touchStartY = null;
+    };
+
+    scroller.addEventListener("touchstart", handleTouchStart);
+    scroller.addEventListener("touchend", handleTouchEnd);
+
+    return () => {
+      scroller.removeEventListener("touchstart", handleTouchStart);
+      scroller.removeEventListener("touchend", handleTouchEnd);
+    };
+  }, [togglePanelFromSwipe]);
 
   const loadMoreRef = useInfiniteScroll({
     isLoading,
@@ -22,22 +103,34 @@ const FeedPage = observer(function FeedPage() {
   const showEmptyState = !isLoading && !isInitialLoad && artPieces.length === 0;
 
   return (
-    <div className="art-feed">
+    <div className={`art-feed ${isLikedPanelOpen ? "has-liked-panel" : ""}`.trim()}>
       <header className="art-feed__header">
         <div className="art-feed__brand">ArtTok</div>
-        <button
-          type="button"
-          className="art-feed__refresh"
-          onClick={() => {
-            artImagesStore.resetFeed();
-            artImagesStore.fetchNextPage();
-          }}
-        >
-          Refresh
-        </button>
+        <div className="art-feed__header-actions">
+          <button
+            type="button"
+            className="art-feed__icon-button"
+            aria-label="Refresh feed"
+            onClick={() => {
+              artImagesStore.resetFeed();
+              artImagesStore.fetchNextPage();
+            }}
+          >
+            <RefreshIcon />
+          </button>
+          <button
+            type="button"
+            className={`art-feed__icon-button ${isLikedPanelOpen ? "is-active" : ""}`.trim()}
+            aria-pressed={isLikedPanelOpen}
+            aria-label="Open liked art collection"
+            onClick={toggleLikedPanel}
+          >
+            <CollectionIcon />
+          </button>
+        </div>
       </header>
 
-      <main className="art-feed__scroller">
+      <main className="art-feed__scroller" ref={scrollerRef}>
         {artPieces.map((piece) => (
           <ArtCard key={piece.id} art={piece} />
         ))}
@@ -69,6 +162,16 @@ const FeedPage = observer(function FeedPage() {
           <div className="art-feed__status">You\'re all caught up for now!</div>
         )}
       </main>
+
+      {isLikedPanelOpen && (
+        <button
+          type="button"
+          className="liked-panel__backdrop"
+          aria-label="Close liked art overlay"
+          onClick={closeLikedPanel}
+        />
+      )}
+      <LikedArtPanel isOpen={isLikedPanelOpen} onClose={closeLikedPanel} />
     </div>
   );
 });

--- a/src/utils/likedArtStorage.ts
+++ b/src/utils/likedArtStorage.ts
@@ -1,0 +1,40 @@
+export const LIKED_ART_STORAGE_KEY = "arttok-liked-art";
+export const LIKED_ART_STORAGE_EVENT = "liked-art:updated";
+
+export function readLikedSet(): Set<number> {
+  if (typeof window === "undefined") {
+    return new Set();
+  }
+
+  try {
+    const raw = window.localStorage.getItem(LIKED_ART_STORAGE_KEY);
+    if (!raw) {
+      return new Set();
+    }
+
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return new Set(parsed.filter((value) => typeof value === "number"));
+    }
+  } catch (error) {
+    console.warn("Failed to read liked art from storage", error);
+  }
+
+  return new Set();
+}
+
+export function writeLikedSet(set: Set<number>) {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(
+      LIKED_ART_STORAGE_KEY,
+      JSON.stringify(Array.from(set)),
+    );
+    window.dispatchEvent(new Event(LIKED_ART_STORAGE_EVENT));
+  } catch (error) {
+    console.warn("Failed to persist liked art to storage", error);
+  }
+}


### PR DESCRIPTION
- restyle the feed to mimic a vertical TikTok layout with cover imagery, balanced typography, and icon-based actions
- add a swipe-activated liked art collection panel that can also be opened from the header and removed likes inline
- share liked-art storage helpers so UI stays in sync across the feed and collection views