### PR TITLE
feat: Instagram auto-poster with watercolor art cards

### DIFF
--- a/.github/workflows/instagram-post.yml
+++ b/.github/workflows/instagram-post.yml
@@ -1,0 +1,53 @@
+name: Instagram Auto-Post
+
+on:
+  schedule:
+    # Every hour at minute 0
+    - cron: "0 * * * *"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Post type"
+        required: false
+        default: "post"
+        type: choice
+        options:
+          - post
+          - story
+
+jobs:
+  post:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # node-canvas native dependencies
+      - name: Install canvas system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libcairo2-dev libpango1.0-dev \
+            libjpeg-dev libgif-dev librsvg2-dev fonts-liberation fonts-dejavu
+
+      - name: Install npm dependencies
+        working-directory: scripts/instagram-poster
+        run: npm install
+
+      - name: Post to Instagram
+        working-directory: scripts/instagram-poster
+        env:
+          INSTAGRAM_ACCESS_TOKEN: ${{ secrets.INSTAGRAM_ACCESS_TOKEN }}
+          INSTAGRAM_USER_ID: ${{ secrets.INSTAGRAM_USER_ID }}
+          DROPBOX_REFRESH_TOKEN: ${{ secrets.DROPBOX_REFRESH_TOKEN }}
+          DROPBOX_APP_KEY: ${{ secrets.DROPBOX_APP_KEY }}
+          DROPBOX_APP_SECRET: ${{ secrets.DROPBOX_APP_SECRET }}
+          HARVARD_API_KEY: ${{ secrets.VITE_HARVARD_API_KEY }}
+        run: |
+          if [ "${{ inputs.mode }}" = "story" ]; then
+            node post.mjs --story
+          else
+            node post.mjs
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ dist-ssr
 .env.local
 .env.*.local
 
+# Instagram poster history
+scripts/instagram-poster/posted-history.json
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/scripts/instagram-poster/.env.example
+++ b/scripts/instagram-poster/.env.example
@@ -1,0 +1,57 @@
+# ============================================================================
+# ArtTok Instagram Auto-Poster — Environment Variables
+# ============================================================================
+# Copy this to .env and fill in your values:
+#   cp .env.example .env
+#
+# For GitHub Actions, add these as repository secrets.
+# ============================================================================
+
+# ── Instagram (Meta Graph API) ──────────────────────────────────────────────
+#
+# SETUP STEPS:
+#
+# 1. Create an Instagram Professional account (Business or Creator)
+#    - Open Instagram > Settings > Account type > Switch to Professional
+#
+# 2. Create a Facebook Page and link it to your Instagram account
+#    - facebook.com/pages/create
+#    - Link: Instagram Settings > Account > Linked Accounts > Facebook
+#
+# 3. Create a Meta Developer App
+#    - Go to: https://developers.facebook.com/apps/
+#    - Click "Create App" > Select "Business" type
+#    - Add the "Instagram Graph API" product
+#
+# 4. Get your Instagram User ID
+#    - In Graph API Explorer (https://developers.facebook.com/tools/explorer/)
+#    - Select your app, get a User Token with these permissions:
+#      instagram_basic, instagram_content_publish, pages_show_list,
+#      pages_read_engagement, business_management
+#    - Query: GET /me/accounts → get the Page ID
+#    - Query: GET /{page-id}?fields=instagram_business_account → get the IG User ID
+#
+# 5. Generate a long-lived Page Access Token
+#    - Exchange short-lived token for long-lived (60 days):
+#      GET /oauth/access_token?grant_type=fb_exchange_token
+#        &client_id={app-id}&client_secret={app-secret}&fb_exchange_token={short-token}
+#    - Then get page token:
+#      GET /me/accounts?access_token={long-lived-user-token}
+#    - The page access token from this call is PERMANENT (never expires)
+#
+INSTAGRAM_ACCESS_TOKEN=your_page_access_token_here
+INSTAGRAM_USER_ID=your_instagram_user_id_here
+
+# ── Facebook Page ID ────────────────────────────────────────────────────────
+#
+# The numeric ID of your Facebook Page (used to upload images).
+# Found in Graph API Explorer: GET /me/accounts → "id" field
+#
+FACEBOOK_PAGE_ID=your_facebook_page_id_here
+
+# ── Harvard Art Museums API ─────────────────────────────────────────────────
+#
+# Optional — Met and AIC work without keys. But Harvard has the best data.
+# Get a free key: https://harvardartmuseums.org/collections/api
+#
+HARVARD_API_KEY=your_harvard_api_key_here

--- a/scripts/instagram-poster/package-lock.json
+++ b/scripts/instagram-poster/package-lock.json
@@ -1,0 +1,471 @@
+{
+  "name": "arttok-instagram-poster",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "arttok-instagram-poster",
+      "version": "1.0.0",
+      "dependencies": {
+        "canvas": "^3.1.0",
+        "dotenv": "^16.5.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/canvas": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.2.tgz",
+      "integrity": "sha512-duEt4h1HHu9sJZyVKfLRXR6tsKPY7cEELzxSRJkwddOXYvQT3P/+es98SV384JA0zMOZ5s+9gatnGfM6sL4Drg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.3"
+      },
+      "engines": {
+        "node": "^18.12.0 || >= 20.9.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    }
+  }
+}

--- a/scripts/instagram-poster/package.json
+++ b/scripts/instagram-poster/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "arttok-instagram-poster",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "post": "node post.mjs",
+    "post:story": "node post.mjs --story",
+    "post:dry-run": "node post.mjs --dry-run"
+  },
+  "dependencies": {
+    "canvas": "^3.1.0",
+    "dotenv": "^16.5.0"
+  }
+}

--- a/scripts/instagram-poster/post.mjs
+++ b/scripts/instagram-poster/post.mjs
@@ -1,0 +1,554 @@
+#!/usr/bin/env node
+/**
+ * ArtTok Instagram Auto-Poster
+ *
+ * Fetches a random artwork from Harvard/Met/AIC, generates a watercolor-style
+ * card (post or story), uploads to Imgur for hosting, then publishes to
+ * Instagram via Meta Graph API.
+ *
+ * Usage:
+ *   node post.mjs              # post (1080x1350 feed)
+ *   node post.mjs --story      # story (1080x1920, disappears in 24h)
+ *   node post.mjs --dry-run    # generate card locally, skip Instagram publish
+ *
+ * Required env vars (see .env.example):
+ *   INSTAGRAM_ACCESS_TOKEN  — long-lived page access token
+ *   INSTAGRAM_USER_ID       — Instagram Business/Creator account ID
+ *   IMGUR_CLIENT_ID         — Imgur app client ID (for temp image hosting)
+ *   HARVARD_API_KEY         — Harvard Art Museums API key
+ */
+import "dotenv/config";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { renderPostCard, renderStoryCard } from "./render.mjs";
+
+// ── Post history (duplicate prevention) ─────────────────────────────────────
+
+const HISTORY_FILE = new URL("./posted-history.json", import.meta.url).pathname.replace(/^\/([A-Z]:)/, "$1");
+const MAX_HISTORY = 5000;
+
+function loadHistory() {
+  if (!existsSync(HISTORY_FILE)) return new Set();
+  try {
+    const data = JSON.parse(readFileSync(HISTORY_FILE, "utf-8"));
+    return new Set(data);
+  } catch {
+    return new Set();
+  }
+}
+
+function saveHistory(history) {
+  const arr = [...history];
+  // Keep only the most recent entries to prevent unbounded growth
+  const trimmed = arr.slice(-MAX_HISTORY);
+  writeFileSync(HISTORY_FILE, JSON.stringify(trimmed, null, 2));
+}
+
+function artKey(art) {
+  return `${art.source}:${art.id}`;
+}
+
+// ── Config ──────────────────────────────────────────────────────────────────
+
+const {
+  INSTAGRAM_ACCESS_TOKEN,
+  INSTAGRAM_USER_ID,
+  HARVARD_API_KEY,
+} = process.env;
+
+const args = process.argv.slice(2);
+const IS_STORY = args.includes("--story");
+const DRY_RUN = args.includes("--dry-run");
+const ART_ARG = args.find((a) => a.startsWith("--art="));
+const SPECIFIC_ART = ART_ARG ? ART_ARG.replace("--art=", "") : null; // e.g. "harvard:229060"
+
+// ── Art source configs ──────────────────────────────────────────────────────
+
+const HARVARD_API = "https://api.harvardartmuseums.org/object";
+const HARVARD_FIELDS = [
+  "objectid", "primaryimageurl", "title", "people", "description",
+  "culture", "dated", "classification", "medium", "url", "images",
+].join(",");
+
+const MET_API = "https://collectionapi.metmuseum.org/public/collection/v1";
+
+const AIC_API = "https://api.artic.edu/api/v1";
+const AIC_IIIF = "https://www.artic.edu/iiif/2";
+const AIC_FIELDS = [
+  "id", "title", "artist_display", "image_id", "place_of_origin",
+  "date_display", "classification_title", "medium_display",
+].join(",");
+
+// ── Fetch helpers ───────────────────────────────────────────────────────────
+
+async function fetchJson(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${url}`);
+  return res.json();
+}
+
+function pick(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+// ── Harvard: random page from top-viewed works ──────────────────────────────
+
+async function fetchHarvardRandom() {
+  if (!HARVARD_API_KEY) throw new Error("HARVARD_API_KEY not set");
+
+  // First get total count
+  const countUrl = `${HARVARD_API}?apikey=${HARVARD_API_KEY}&size=1&hasimage=1&q=verificationlevel:4&fields=objectid`;
+  const countData = await fetchJson(countUrl);
+  const totalPages = Math.min(countData.info.pages, 200);
+
+  // Random page
+  const page = Math.floor(Math.random() * totalPages) + 1;
+  const url = `${HARVARD_API}?apikey=${HARVARD_API_KEY}&size=10&page=${page}&hasimage=1&q=verificationlevel:4&sort=totalpageviews&sortorder=desc&fields=${HARVARD_FIELDS}`;
+  const data = await fetchJson(url);
+
+  const records = data.records.filter((r) => r.primaryimageurl);
+  if (records.length === 0) throw new Error("No Harvard artworks with images on this page");
+
+  const r = pick(records);
+  const artist = r.people?.map((p) => p.name).filter(Boolean).join(", ") || "Unknown artist";
+
+  return {
+    id: r.objectid,
+    title: r.title || "Untitled",
+    artist,
+    imageUrl: r.primaryimageurl,
+    source: "harvard",
+    culture: r.culture,
+    dated: r.dated,
+    classification: r.classification,
+    medium: r.medium,
+    url: r.url || `https://harvardartmuseums.org/collections/object/${r.objectid}`,
+    museumName: "Harvard Art Museums",
+  };
+}
+
+// ── Met: random from highlights ─────────────────────────────────────────────
+
+async function fetchMetRandom() {
+  const searchUrl = `${MET_API}/search?hasImages=true&isHighlight=true&q=*`;
+  const data = await fetchJson(searchUrl);
+  const ids = data.objectIDs;
+  if (!ids || ids.length === 0) throw new Error("No Met highlights found");
+
+  // Try up to 5 random picks (some objects may lack images)
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const id = pick(ids);
+    try {
+      const obj = await fetchJson(`${MET_API}/objects/${id}`);
+      const imageUrl = obj.primaryImage || obj.primaryImageSmall;
+      if (!imageUrl) continue;
+
+      return {
+        id: obj.objectID,
+        title: obj.title || "Untitled",
+        artist: obj.artistDisplayName || "Unknown artist",
+        imageUrl,
+        source: "met",
+        culture: obj.culture,
+        dated: obj.objectDate,
+        classification: obj.classification,
+        medium: obj.medium,
+        url: obj.objectURL || `https://www.metmuseum.org/art/collection/search/${obj.objectID}`,
+        museumName: "The Metropolitan Museum of Art",
+      };
+    } catch {
+      continue;
+    }
+  }
+  throw new Error("Failed to find Met artwork with image after 5 attempts");
+}
+
+// ── AIC: random from search ────────────────────────────────────────────────
+
+async function fetchAicRandom() {
+  // Get total, pick random page
+  const countUrl = `${AIC_API}/artworks/search?q=*&limit=1&fields=id`;
+  const countData = await fetchJson(countUrl);
+  const totalPages = Math.min(countData.pagination.total_pages, 200);
+
+  const page = Math.floor(Math.random() * totalPages) + 1;
+  const url = `${AIC_API}/artworks/search?q=*&page=${page}&limit=10&fields=${AIC_FIELDS}`;
+  const data = await fetchJson(url);
+
+  const records = data.data.filter((r) => r.image_id);
+  if (records.length === 0) throw new Error("No AIC artworks with images on this page");
+
+  const r = pick(records);
+  return {
+    id: r.id,
+    title: r.title || "Untitled",
+    artist: r.artist_display || "Unknown artist",
+    imageUrl: `${AIC_IIIF}/${r.image_id}/full/843,/0/default.jpg`,
+    source: "artic",
+    culture: r.place_of_origin,
+    dated: r.date_display,
+    classification: r.classification_title,
+    medium: r.medium_display,
+    url: `https://www.artic.edu/artworks/${r.id}`,
+    museumName: "Art Institute of Chicago",
+  };
+}
+
+// ── Fetch specific artwork by source:id ─────────────────────────────────────
+
+async function fetchSpecificArtwork(sourceId) {
+  const [source, id] = sourceId.split(":");
+  if (!source || !id) throw new Error(`Invalid --art format. Use: --art=harvard:229060`);
+
+  console.log(`Fetching ${source}:${id}...`);
+
+  if (source === "harvard") {
+    if (!HARVARD_API_KEY) throw new Error("HARVARD_API_KEY not set");
+    const url = `${HARVARD_API}/${id}?apikey=${HARVARD_API_KEY}&fields=${HARVARD_FIELDS}`;
+    const r = await fetchJson(url);
+    if (!r.primaryimageurl) throw new Error("This artwork has no image");
+    const artist = r.people?.map((p) => p.name).filter(Boolean).join(", ") || "Unknown artist";
+    return {
+      id: r.objectid, title: r.title || "Untitled", artist,
+      imageUrl: r.primaryimageurl, source: "harvard", culture: r.culture,
+      dated: r.dated, classification: r.classification, medium: r.medium,
+      url: r.url || `https://harvardartmuseums.org/collections/object/${r.objectid}`,
+      museumName: "Harvard Art Museums",
+    };
+  }
+
+  if (source === "met") {
+    const obj = await fetchJson(`${MET_API}/objects/${id}`);
+    const imageUrl = obj.primaryImage || obj.primaryImageSmall;
+    if (!imageUrl) throw new Error("This artwork has no image");
+    return {
+      id: obj.objectID, title: obj.title || "Untitled",
+      artist: obj.artistDisplayName || "Unknown artist", imageUrl, source: "met",
+      culture: obj.culture, dated: obj.objectDate, classification: obj.classification,
+      medium: obj.medium,
+      url: obj.objectURL || `https://www.metmuseum.org/art/collection/search/${obj.objectID}`,
+      museumName: "The Metropolitan Museum of Art",
+    };
+  }
+
+  if (source === "artic" || source === "aic") {
+    const data = await fetchJson(`${AIC_API}/artworks/${id}?fields=${AIC_FIELDS}`);
+    const r = data.data;
+    if (!r.image_id) throw new Error("This artwork has no image");
+    return {
+      id: r.id, title: r.title || "Untitled",
+      artist: r.artist_display || "Unknown artist",
+      imageUrl: `${AIC_IIIF}/${r.image_id}/full/843,/0/default.jpg`,
+      source: "artic", culture: r.place_of_origin, dated: r.date_display,
+      classification: r.classification_title, medium: r.medium_display,
+      url: `https://www.artic.edu/artworks/${r.id}`,
+      museumName: "Art Institute of Chicago",
+    };
+  }
+
+  throw new Error(`Unknown source: ${source}. Use harvard, met, or artic.`);
+}
+
+// ── Random artwork from any source ──────────────────────────────────────────
+
+const SOURCES = [
+  { name: "Harvard", fn: fetchHarvardRandom, needsKey: true },
+  { name: "Met", fn: fetchMetRandom, needsKey: false },
+  { name: "AIC", fn: fetchAicRandom, needsKey: false },
+];
+
+async function fetchRandomArtwork(history) {
+  // Filter to sources we can use (Harvard needs API key)
+  const available = SOURCES.filter((s) => !s.needsKey || HARVARD_API_KEY);
+
+  // Try up to 10 times across all sources to find a non-duplicate
+  for (let round = 0; round < 10; round++) {
+    const shuffled = available.sort(() => Math.random() - 0.5);
+
+    for (const source of shuffled) {
+      try {
+        if (round === 0) console.log(`Trying ${source.name}...`);
+        const art = await source.fn();
+        const key = artKey(art);
+
+        if (history.has(key)) {
+          console.log(`Skipping duplicate: "${art.title}" [${key}]`);
+          continue;
+        }
+
+        console.log(`Got: "${art.title}" by ${art.artist} [${source.name}]`);
+        return art;
+      } catch (err) {
+        if (round === 0) console.warn(`${source.name} failed: ${err.message}`);
+      }
+    }
+  }
+
+  throw new Error("All art sources failed or all results were duplicates");
+}
+
+// ── Dropbox upload (confirmed working with Instagram API) ───────────────────
+
+const {
+  DROPBOX_REFRESH_TOKEN,
+  DROPBOX_APP_KEY,
+  DROPBOX_APP_SECRET,
+} = process.env;
+
+async function getDropboxToken() {
+  if (!DROPBOX_REFRESH_TOKEN || !DROPBOX_APP_KEY || !DROPBOX_APP_SECRET) {
+    throw new Error("DROPBOX_REFRESH_TOKEN, DROPBOX_APP_KEY, and DROPBOX_APP_SECRET must be set");
+  }
+
+  const res = await fetch("https://api.dropboxapi.com/oauth2/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: DROPBOX_REFRESH_TOKEN,
+      client_id: DROPBOX_APP_KEY,
+      client_secret: DROPBOX_APP_SECRET,
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Dropbox token refresh failed (${res.status}): ${body}`);
+  }
+
+  const data = await res.json();
+  return data.access_token;
+}
+
+async function uploadImage(imageBuffer) {
+  const token = await getDropboxToken();
+  const filename = `arttok-${Date.now()}.jpg`;
+  const path = `/arttok/${filename}`;
+
+  // 1. Upload file
+  const uploadRes = await fetch("https://content.dropboxapi.com/2/files/upload", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/octet-stream",
+      "Dropbox-API-Arg": JSON.stringify({
+        path,
+        mode: "overwrite",
+        mute: true,
+      }),
+    },
+    body: imageBuffer,
+  });
+
+  if (!uploadRes.ok) {
+    const body = await uploadRes.text();
+    throw new Error(`Dropbox upload failed (${uploadRes.status}): ${body}`);
+  }
+
+  // 2. Create shared link
+  const shareRes = await fetch("https://api.dropboxapi.com/2/sharing/create_shared_link_with_settings", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      path,
+      settings: { requested_visibility: { ".tag": "public" } },
+    }),
+  });
+
+  let shareUrl;
+  if (shareRes.ok) {
+    const shareData = await shareRes.json();
+    shareUrl = shareData.url;
+  } else {
+    // Link may already exist — try to get existing
+    const listRes = await fetch("https://api.dropboxapi.com/2/sharing/list_shared_links", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ path, direct_only: true }),
+    });
+    const listData = await listRes.json();
+    shareUrl = listData.links?.[0]?.url;
+    if (!shareUrl) throw new Error("Failed to create or find Dropbox shared link");
+  }
+
+  // 3. Convert to direct download URL (replace dl=0 with raw=1)
+  const directUrl = shareUrl.replace(/\?dl=0$/, "?raw=1").replace(/&dl=0/, "&raw=1");
+  return { url: directUrl, path, token };
+}
+
+async function deleteFromDropbox(path, token) {
+  try {
+    await fetch("https://api.dropboxapi.com/2/files/delete_v2", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ path }),
+    });
+    console.log("Cleaned up Dropbox file");
+  } catch {
+    // Non-fatal — file will just stay in Dropbox
+  }
+}
+
+// ── Instagram Graph API publishing ──────────────────────────────────────────
+
+const IG_GRAPH = "https://graph.facebook.com/v21.0";
+
+async function publishToInstagram(imageUrl, caption, isStory = false) {
+  if (!INSTAGRAM_ACCESS_TOKEN) throw new Error("INSTAGRAM_ACCESS_TOKEN not set");
+  if (!INSTAGRAM_USER_ID) throw new Error("INSTAGRAM_USER_ID not set");
+
+  // Step 1: Create media container
+  const containerParams = new URLSearchParams({
+    image_url: imageUrl,
+    caption: isStory ? "" : caption, // stories don't support captions via API
+    access_token: INSTAGRAM_ACCESS_TOKEN,
+  });
+
+  if (isStory) {
+    containerParams.set("media_type", "STORIES");
+  }
+
+  const containerRes = await fetch(
+    `${IG_GRAPH}/${INSTAGRAM_USER_ID}/media?${containerParams.toString()}`,
+    { method: "POST" },
+  );
+
+  if (!containerRes.ok) {
+    const body = await containerRes.text();
+    throw new Error(`Instagram container creation failed (${containerRes.status}): ${body}`);
+  }
+
+  const { id: containerId } = await containerRes.json();
+  console.log(`Container created: ${containerId}`);
+
+  // Step 2: Wait for container to be ready (Instagram processes the image)
+  await waitForContainer(containerId);
+
+  // Step 3: Publish
+  const publishRes = await fetch(
+    `${IG_GRAPH}/${INSTAGRAM_USER_ID}/media_publish`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        creation_id: containerId,
+        access_token: INSTAGRAM_ACCESS_TOKEN,
+      }).toString(),
+    },
+  );
+
+  if (!publishRes.ok) {
+    const body = await publishRes.text();
+    throw new Error(`Instagram publish failed (${publishRes.status}): ${body}`);
+  }
+
+  const { id: mediaId } = await publishRes.json();
+  return mediaId;
+}
+
+async function waitForContainer(containerId, maxAttempts = 10) {
+  for (let i = 0; i < maxAttempts; i++) {
+    const res = await fetch(
+      `${IG_GRAPH}/${containerId}?fields=status_code&access_token=${INSTAGRAM_ACCESS_TOKEN}`,
+    );
+    const data = await res.json();
+
+    if (data.status_code === "FINISHED") return;
+    if (data.status_code === "ERROR") throw new Error("Instagram container processing failed");
+
+    console.log(`Container status: ${data.status_code} (attempt ${i + 1}/${maxAttempts})`);
+    await new Promise((r) => setTimeout(r, 3000));
+  }
+  throw new Error("Instagram container processing timed out");
+}
+
+// ── Caption builder ─────────────────────────────────────────────────────────
+
+function buildCaption(art) {
+  const lines = [];
+
+  lines.push(`\uD83C\uDFA8 ${art.title}`);
+  if (art.artist !== "Unknown artist") lines.push(`\u270F\uFE0F ${art.artist}`);
+  if (art.dated) lines.push(`\uD83D\uDCC5 ${art.dated}`);
+  lines.push(`\uD83C\uDFDB\uFE0F ${art.museumName}`);
+  lines.push("");
+  if (art.medium) lines.push(art.medium);
+  lines.push("");
+  lines.push(`\uD83D\uDD17 ${art.url}`);
+  lines.push("");
+
+  lines.push("Follow @arttok.art for daily masterworks from the world's greatest museums.");
+  lines.push("");
+
+  // Hashtags
+  const tags = ["#arttok", "#art", "#museum", "#artwork", "#fineart", "#dailyart", "#arthistory", "#classicart", "#masterpiece", "#artlovers"];
+  if (art.culture) tags.push(`#${art.culture.replace(/\s+/g, "").toLowerCase()}`);
+  if (art.classification) tags.push(`#${art.classification.replace(/[\s,]+/g, "").toLowerCase()}`);
+  tags.push(`#${art.source === "harvard" ? "harvardartmuseums" : art.source === "met" ? "themet" : "artinstituteofchicago"}`);
+  lines.push(tags.join(" "));
+
+  return lines.join("\n");
+}
+
+// ── Main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log(`ArtTok Instagram Poster — ${IS_STORY ? "Story" : "Post"} mode${DRY_RUN ? " (dry run)" : ""}`);
+  console.log("─".repeat(50));
+
+  // 1. Fetch artwork (specific or random, skip previously posted)
+  const history = loadHistory();
+  console.log(`History: ${history.size} previously posted artworks`);
+  const art = SPECIFIC_ART
+    ? await fetchSpecificArtwork(SPECIFIC_ART)
+    : await fetchRandomArtwork(history);
+
+  // 2. Render card
+  console.log(`Rendering ${IS_STORY ? "story" : "post"} card...`);
+  const renderFn = IS_STORY ? renderStoryCard : renderPostCard;
+  const pngBuffer = await renderFn(art, art.imageUrl);
+  console.log(`Card rendered: ${(pngBuffer.length / 1024).toFixed(0)} KB`);
+
+  // In dry-run mode, save locally and exit
+  if (DRY_RUN) {
+    const filename = `arttok-${art.source}-${art.id}-${IS_STORY ? "story" : "post"}.jpg`;
+    writeFileSync(filename, pngBuffer);
+    console.log(`\nSaved to ${filename}`);
+    console.log(`\nCaption:\n${buildCaption(art)}`);
+    return;
+  }
+
+  // 3. Upload for public URL
+  console.log("Uploading image...");
+  const { url: publicUrl, path: dropboxPath, token: dropboxToken } = await uploadImage(pngBuffer);
+  console.log(`Hosted at: ${publicUrl}`);
+
+  // 4. Publish to Instagram
+  console.log("Publishing to Instagram...");
+  const caption = buildCaption(art);
+  const mediaId = await publishToInstagram(publicUrl, caption, IS_STORY);
+
+  // 5. Clean up Dropbox file (Instagram already downloaded it)
+  await deleteFromDropbox(dropboxPath, dropboxToken);
+
+  // 6. Record in history
+  history.add(artKey(art));
+  saveHistory(history);
+
+  console.log("─".repeat(50));
+  console.log(`Published! Media ID: ${mediaId}`);
+  console.log(`"${art.title}" by ${art.artist}`);
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err.message);
+  process.exit(1);
+});

--- a/scripts/instagram-poster/render.mjs
+++ b/scripts/instagram-poster/render.mjs
@@ -1,0 +1,501 @@
+/**
+ * Story/Post card renderer for Node.js — ported from src/utils/storyCardRenderer.ts
+ * Uses node-canvas (same Canvas API as browser) to generate watercolor-style art cards.
+ */
+import { createCanvas, loadImage } from "canvas";
+
+// ── Image loader with referrer spoofing for blocked sources (AIC IIIF) ──────
+const REFERRERS = {
+  "www.artic.edu": "https://www.artic.edu/",
+};
+
+async function fetchImage(url) {
+  const hostname = new URL(url).hostname;
+  const referrer = REFERRERS[hostname];
+
+  if (referrer) {
+    const res = await fetch(url, { headers: { Referer: referrer } });
+    if (!res.ok) throw new Error(`Image fetch failed: ${res.status}`);
+    const buffer = Buffer.from(await res.arrayBuffer());
+    return loadImage(buffer);
+  }
+
+  return loadImage(url);
+}
+
+// ── Dimensions ──────────────────────────────────────────────────────────────
+const STORY_W = 1080;
+const STORY_H = 1920;
+const POST_W = 1080;
+const POST_H = 1350;
+
+// ── Text helpers ────────────────────────────────────────────────────────────
+
+function truncateText(ctx, text, maxWidth, maxLines) {
+  const words = text.split(/\s+/);
+  const lines = [];
+  let current = "";
+
+  for (const word of words) {
+    const test = current ? `${current} ${word}` : word;
+    if (ctx.measureText(test).width > maxWidth && current) {
+      lines.push(current);
+      if (lines.length >= maxLines) break;
+      current = word;
+    } else {
+      current = test;
+    }
+  }
+
+  if (current && lines.length < maxLines) {
+    lines.push(current);
+  }
+
+  if (lines.length === maxLines) {
+    const last = lines[maxLines - 1];
+    if (ctx.measureText(last).width > maxWidth) {
+      let trimmed = last;
+      while (ctx.measureText(trimmed + "\u2026").width > maxWidth && trimmed.length > 0) {
+        trimmed = trimmed.slice(0, -1).trimEnd();
+      }
+      lines[maxLines - 1] = trimmed + "\u2026";
+    }
+  }
+
+  return lines;
+}
+
+// ── Color palette extraction (Median Cut) ───────────────────────────────────
+
+const FALLBACK_PALETTES = [
+  ["#E8845C", "#F4A261", "#E76F51", "#F2CC8F", "#D4A373"],
+  ["#C97B63", "#E0A899", "#D4856B", "#F0D2C4", "#B5654A"],
+  ["#D4A03C", "#E8C468", "#C4883C", "#F2D98C", "#B07828"],
+  ["#C07088", "#D4949C", "#B85878", "#E8B8C0", "#A04468"],
+  ["#C89640", "#D8B06C", "#B87C2C", "#E8CC94", "#A06820"],
+];
+
+function extractPalette(img, count = 5) {
+  const size = 100;
+  const c = createCanvas(size, size);
+  const cx = c.getContext("2d");
+
+  cx.drawImage(img, 0, 0, size, size);
+  const { data } = cx.getImageData(0, 0, size, size);
+
+  const pixels = [];
+  for (let i = 0; i < data.length; i += 4) {
+    const r = data[i], g = data[i + 1], b = data[i + 2], a = data[i + 3];
+    if (a < 128) continue;
+    const lum = r * 0.299 + g * 0.587 + b * 0.114;
+    if (lum > 245 || lum < 10) continue;
+    pixels.push([r, g, b]);
+  }
+
+  if (pixels.length < count) return [];
+
+  function channelRange(box, ch) {
+    let min = 255, max = 0;
+    for (const px of box) {
+      if (px[ch] < min) min = px[ch];
+      if (px[ch] > max) max = px[ch];
+    }
+    return max - min;
+  }
+
+  function widestChannel(box) {
+    const rr = channelRange(box, 0);
+    const gr = channelRange(box, 1);
+    const br = channelRange(box, 2);
+    if (rr >= gr && rr >= br) return 0;
+    if (gr >= rr && gr >= br) return 1;
+    return 2;
+  }
+
+  function splitBox(box) {
+    const ch = widestChannel(box);
+    box.sort((a, b) => a[ch] - b[ch]);
+    const mid = Math.floor(box.length / 2);
+    return [box.slice(0, mid), box.slice(mid)];
+  }
+
+  function averageColor(box) {
+    let rSum = 0, gSum = 0, bSum = 0;
+    for (const [r, g, b] of box) { rSum += r; gSum += g; bSum += b; }
+    const n = box.length;
+    return [Math.round(rSum / n), Math.round(gSum / n), Math.round(bSum / n)];
+  }
+
+  const boxes = [pixels];
+  while (boxes.length < count) {
+    let bestIdx = 0, bestRange = 0;
+    for (let i = 0; i < boxes.length; i++) {
+      if (boxes[i].length < 2) continue;
+      const ch = widestChannel(boxes[i]);
+      const range = channelRange(boxes[i], ch);
+      if (range > bestRange) { bestRange = range; bestIdx = i; }
+    }
+    if (bestRange === 0) break;
+    const [a, b] = splitBox(boxes[bestIdx]);
+    boxes.splice(bestIdx, 1, a, b);
+  }
+
+  boxes.sort((a, b) => b.length - a.length);
+
+  return boxes.slice(0, count).map((box) => {
+    const [r, g, b] = averageColor(box);
+    const rf = r / 255, gf = g / 255, bf = b / 255;
+    const max = Math.max(rf, gf, bf), min = Math.min(rf, gf, bf);
+    const l = (max + min) / 2;
+    let h = 0, s = 0;
+    if (max !== min) {
+      const d = max - min;
+      s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+      if (max === rf) h = ((gf - bf) / d + (gf < bf ? 6 : 0)) / 6;
+      else if (max === gf) h = ((bf - rf) / d + 2) / 6;
+      else h = ((rf - gf) / d + 4) / 6;
+    }
+    const boostedS = Math.min(s * 1.2, 0.85);
+    const boostedL = Math.min(l + (1 - l) * 0.1, 0.85);
+
+    const hue2rgb = (p, q, t) => {
+      if (t < 0) t += 1; if (t > 1) t -= 1;
+      if (t < 1 / 6) return p + (q - p) * 6 * t;
+      if (t < 1 / 2) return q;
+      if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+      return p;
+    };
+    const q2 = boostedL < 0.5 ? boostedL * (1 + boostedS) : boostedL + boostedS - boostedL * boostedS;
+    const p2 = 2 * boostedL - q2;
+    const or = Math.round(hue2rgb(p2, q2, h + 1 / 3) * 255);
+    const og = Math.round(hue2rgb(p2, q2, h) * 255);
+    const ob = Math.round(hue2rgb(p2, q2, h - 1 / 3) * 255);
+
+    return `#${or.toString(16).padStart(2, "0")}${og.toString(16).padStart(2, "0")}${ob.toString(16).padStart(2, "0")}`;
+  });
+}
+
+// ── Seeded RNG ──────────────────────────────────────────────────────────────
+
+function mulberry32(seed) {
+  let s = seed | 0;
+  return () => {
+    s = (s + 0x6d2b79f5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// ── Watercolor geometry ─────────────────────────────────────────────────────
+
+function basePolygon(cx, cy, rx, ry, n, rng) {
+  const pts = [];
+  for (let i = 0; i < n; i++) {
+    const angle = (i / n) * Math.PI * 2;
+    const wobble = 0.85 + rng() * 0.3;
+    pts.push({ x: cx + Math.cos(angle) * rx * wobble, y: cy + Math.sin(angle) * ry * wobble });
+  }
+  return pts;
+}
+
+function deformPolygon(pts, depth, variance, rng) {
+  let current = pts;
+  for (let d = 0; d < depth; d++) {
+    const next = [];
+    for (let i = 0; i < current.length; i++) {
+      const a = current[i];
+      const b = current[(i + 1) % current.length];
+      const mx = (a.x + b.x) / 2;
+      const my = (a.y + b.y) / 2;
+      const dx = b.x - a.x;
+      const dy = b.y - a.y;
+      const len = Math.sqrt(dx * dx + dy * dy) || 1;
+      const nx = -dy / len;
+      const ny = dx / len;
+      const disp = (rng() - 0.5) * len * variance;
+      next.push(a);
+      next.push({ x: mx + nx * disp, y: my + ny * disp });
+    }
+    current = next;
+  }
+  return current;
+}
+
+function drawPoly(ctx, pts) {
+  ctx.beginPath();
+  ctx.moveTo(pts[0].x, pts[0].y);
+  for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].x, pts[i].y);
+  ctx.closePath();
+}
+
+// ── Watercolor effects ──────────────────────────────────────────────────────
+
+function watercolorWash(ctx, poly, color, rng, layers = 60, layerAlpha = 0.018) {
+  ctx.save();
+  ctx.globalCompositeOperation = "multiply";
+  ctx.fillStyle = color;
+  for (let i = 0; i < layers; i++) {
+    const deformed = deformPolygon(poly, 4, 0.5 + rng() * 0.3, rng);
+    ctx.globalAlpha = layerAlpha * (0.6 + rng() * 0.8);
+    drawPoly(ctx, deformed);
+    ctx.fill();
+  }
+  ctx.restore();
+
+  ctx.save();
+  ctx.globalCompositeOperation = "multiply";
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 1.5;
+  for (let i = 0; i < 10; i++) {
+    const deformed = deformPolygon(poly, 3, 0.3, rng);
+    ctx.globalAlpha = 0.008 + rng() * 0.006;
+    drawPoly(ctx, deformed);
+    ctx.stroke();
+  }
+  ctx.restore();
+}
+
+function wetBloom(ctx, cx, cy, radius, color, rng) {
+  ctx.save();
+  ctx.globalCompositeOperation = "multiply";
+  for (let i = 0; i < 15; i++) {
+    const ox = (rng() - 0.5) * radius * 0.5;
+    const oy = (rng() - 0.5) * radius * 0.5;
+    const r = radius * (0.6 + rng() * 0.6);
+    ctx.globalAlpha = 0.02 + rng() * 0.02;
+    const grad = ctx.createRadialGradient(cx + ox, cy + oy, 0, cx + ox, cy + oy, r);
+    grad.addColorStop(0, color);
+    grad.addColorStop(0.6, color);
+    grad.addColorStop(1, "transparent");
+    ctx.fillStyle = grad;
+    ctx.fillRect(cx + ox - r, cy + oy - r, r * 2, r * 2);
+  }
+  ctx.restore();
+}
+
+function applyPaperTexture(ctx, rng, w, h) {
+  const scale = 4;
+  const tw = Math.ceil(w / scale);
+  const th = Math.ceil(h / scale);
+  const tc = createCanvas(tw, th);
+  const tx = tc.getContext("2d");
+  const img = tx.createImageData(tw, th);
+
+  for (let i = 0; i < img.data.length; i += 4) {
+    const noise = 215 + rng() * 40;
+    img.data[i] = noise;
+    img.data[i + 1] = noise - 2;
+    img.data[i + 2] = noise - 5;
+    img.data[i + 3] = 255;
+  }
+  tx.putImageData(img, 0, 0);
+
+  ctx.save();
+  ctx.globalCompositeOperation = "multiply";
+  ctx.globalAlpha = 0.6;
+  ctx.imageSmoothingEnabled = true;
+  ctx.drawImage(tc, 0, 0, w, h);
+  ctx.restore();
+}
+
+function drawWatercolorBackground(ctx, seed, w, h, imagePalette) {
+  const palette =
+    imagePalette && imagePalette.length >= 3
+      ? imagePalette
+      : FALLBACK_PALETTES[seed % FALLBACK_PALETTES.length];
+  const rng = mulberry32(seed);
+
+  ctx.fillStyle = "#FEFCF9";
+  ctx.fillRect(0, 0, w, h);
+
+  const washCount = 4 + Math.floor(rng() * 3);
+  const washes = [];
+  for (let i = 0; i < washCount; i++) {
+    washes.push({
+      cx: rng() * w, cy: rng() * h,
+      rx: 200 + rng() * 350, ry: 200 + rng() * 350,
+      color: palette[Math.floor(rng() * palette.length)],
+    });
+  }
+
+  for (const ws of washes) {
+    const poly = basePolygon(ws.cx, ws.cy, ws.rx, ws.ry, 12, rng);
+    watercolorWash(ctx, poly, ws.color, rng, 60, 0.018);
+  }
+
+  for (let i = 0; i < washes.length; i++) {
+    const a = washes[i];
+    const b = washes[(i + 1) % washes.length];
+    const blendCx = (a.cx + b.cx) / 2 + (rng() - 0.5) * 200;
+    const blendCy = (a.cy + b.cy) / 2 + (rng() - 0.5) * 200;
+    const blendR = 120 + rng() * 180;
+    const poly = basePolygon(blendCx, blendCy, blendR, blendR * (0.6 + rng() * 0.8), 10, rng);
+    watercolorWash(ctx, poly, rng() > 0.5 ? a.color : b.color, rng, 35, 0.014);
+  }
+
+  for (let i = 0; i < 3; i++) {
+    const ws = washes[Math.floor(rng() * washes.length)];
+    wetBloom(ctx, ws.cx + (rng() - 0.5) * ws.rx, ws.cy + (rng() - 0.5) * ws.ry, 100 + rng() * 150, ws.color, rng);
+  }
+
+  ctx.save();
+  ctx.globalCompositeOperation = "multiply";
+  for (let i = 0; i < 30; i++) {
+    const ws = washes[Math.floor(rng() * washes.length)];
+    const sx = ws.cx + (rng() - 0.5) * ws.rx * 2.5;
+    const sy = ws.cy + (rng() - 0.5) * ws.ry * 2.5;
+    const sr = 2 + rng() * 8;
+    ctx.globalAlpha = 0.03 + rng() * 0.05;
+    ctx.fillStyle = ws.color;
+    ctx.beginPath();
+    ctx.arc(sx, sy, sr, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.restore();
+
+  applyPaperTexture(ctx, rng, w, h);
+
+  ctx.globalAlpha = 1;
+  ctx.globalCompositeOperation = "source-over";
+}
+
+// ── Card renderers ──────────────────────────────────────────────────────────
+
+/**
+ * Render a 1080x1350 Instagram feed post card.
+ * @param {object} art - ArtPiece-like object with { id, title, artist, imageUrl }
+ * @param {string} imageUrl - URL of the artwork image
+ * @returns {Promise<Buffer>} PNG buffer
+ */
+export async function renderPostCard(art, imageUrl) {
+  const img = await fetchImage(imageUrl);
+
+  const canvas = createCanvas(POST_W, POST_H);
+  const ctx = canvas.getContext("2d");
+
+  const imagePalette = extractPalette(img);
+  drawWatercolorBackground(ctx, Math.abs(art.id), POST_W, POST_H, imagePalette);
+
+  const padding = 70;
+  const captionHeight = 180;
+  const availW = POST_W - padding * 2;
+  const availH = POST_H - padding * 2 - captionHeight;
+
+  const scale = Math.min(availW / img.width, availH / img.height, 1);
+  const artW = Math.round(img.width * scale);
+  const artH = Math.round(img.height * scale);
+  const artX = Math.round((POST_W - artW) / 2);
+  const artY = padding + Math.round((availH - artH) / 2);
+
+  ctx.save();
+  ctx.shadowColor = "rgba(0, 0, 0, 0.15)";
+  ctx.shadowBlur = 28;
+  ctx.shadowOffsetY = 6;
+  ctx.drawImage(img, artX, artY, artW, artH);
+  ctx.restore();
+
+  const fadeTop = artY + artH - 10;
+  const fadeGrad = ctx.createLinearGradient(0, fadeTop, 0, POST_H);
+  fadeGrad.addColorStop(0, "rgba(254, 252, 249, 0)");
+  fadeGrad.addColorStop(0.2, "rgba(254, 252, 249, 0.75)");
+  fadeGrad.addColorStop(0.5, "rgba(254, 252, 249, 0.92)");
+  fadeGrad.addColorStop(1, "rgba(254, 252, 249, 0.95)");
+  ctx.fillStyle = fadeGrad;
+  ctx.fillRect(0, fadeTop, POST_W, POST_H - fadeTop);
+
+  const captionY = artY + artH + 28;
+  const captionMaxW = POST_W - padding * 2;
+
+  ctx.fillStyle = "#2a2a2a";
+  ctx.font = 'italic 38px "Georgia", "Liberation Serif", "Times New Roman", serif';
+  ctx.textAlign = "center";
+  ctx.textBaseline = "top";
+
+  const titleLines = truncateText(ctx, art.title, captionMaxW, 2);
+  let lineY = captionY;
+  for (const line of titleLines) {
+    ctx.fillText(line, POST_W / 2, lineY);
+    lineY += 48;
+  }
+
+  ctx.fillStyle = "#888";
+  ctx.font = '300 24px "Liberation Sans", "Helvetica Neue", Arial, sans-serif';
+  const artistText = art.artist.length > 50 ? art.artist.slice(0, 47) + "\u2026" : art.artist;
+  ctx.fillText(artistText, POST_W / 2, lineY + 4);
+
+  ctx.fillStyle = "#555";
+  ctx.font = 'italic 800 22px "Georgia", "Liberation Serif", serif';
+  ctx.fillText("A R T T O K", POST_W / 2, POST_H - 44);
+
+  return canvas.toBuffer("image/jpeg", { quality: 0.95 });
+}
+
+/**
+ * Render a 1080x1920 Instagram story card.
+ * @param {object} art - ArtPiece-like object with { id, title, artist, imageUrl }
+ * @param {string} imageUrl - URL of the artwork image
+ * @returns {Promise<Buffer>} PNG buffer
+ */
+export async function renderStoryCard(art, imageUrl) {
+  const img = await fetchImage(imageUrl);
+
+  const canvas = createCanvas(STORY_W, STORY_H);
+  const ctx = canvas.getContext("2d");
+
+  const imagePalette = extractPalette(img);
+  drawWatercolorBackground(ctx, Math.abs(art.id), STORY_W, STORY_H, imagePalette);
+
+  const padding = 80;
+  const captionHeight = 200;
+  const availW = STORY_W - padding * 2;
+  const availH = STORY_H - padding * 2 - captionHeight;
+
+  const scale = Math.min(availW / img.width, availH / img.height, 1);
+  const artW = Math.round(img.width * scale);
+  const artH = Math.round(img.height * scale);
+  const artX = Math.round((STORY_W - artW) / 2);
+  const artY = padding + Math.round((availH - artH) / 2);
+
+  ctx.save();
+  ctx.shadowColor = "rgba(0, 0, 0, 0.15)";
+  ctx.shadowBlur = 32;
+  ctx.shadowOffsetY = 8;
+  ctx.drawImage(img, artX, artY, artW, artH);
+  ctx.restore();
+
+  const fadeTop = artY + artH - 10;
+  const fadeGrad = ctx.createLinearGradient(0, fadeTop, 0, STORY_H);
+  fadeGrad.addColorStop(0, "rgba(254, 252, 249, 0)");
+  fadeGrad.addColorStop(0.15, "rgba(254, 252, 249, 0.75)");
+  fadeGrad.addColorStop(0.4, "rgba(254, 252, 249, 0.92)");
+  fadeGrad.addColorStop(1, "rgba(254, 252, 249, 0.95)");
+  ctx.fillStyle = fadeGrad;
+  ctx.fillRect(0, fadeTop, STORY_W, STORY_H - fadeTop);
+
+  const captionY = artY + artH + 40;
+  const captionMaxW = STORY_W - padding * 2;
+
+  ctx.fillStyle = "#2a2a2a";
+  ctx.font = 'italic 42px "Georgia", "Liberation Serif", "Times New Roman", serif';
+  ctx.textAlign = "center";
+  ctx.textBaseline = "top";
+
+  const titleLines = truncateText(ctx, art.title, captionMaxW, 2);
+  let lineY = captionY;
+  for (const line of titleLines) {
+    ctx.fillText(line, STORY_W / 2, lineY);
+    lineY += 54;
+  }
+
+  ctx.fillStyle = "#888";
+  ctx.font = '300 28px "Liberation Sans", "Helvetica Neue", Arial, sans-serif';
+  const artistText = art.artist.length > 50 ? art.artist.slice(0, 47) + "\u2026" : art.artist;
+  ctx.fillText(artistText, STORY_W / 2, lineY + 8);
+
+  ctx.fillStyle = "#555";
+  ctx.font = 'italic 800 26px "Georgia", "Liberation Serif", serif';
+  ctx.fillText("A R T T O K", STORY_W / 2, STORY_H - 60);
+
+  return canvas.toBuffer("image/jpeg", { quality: 0.95 });
+}


### PR DESCRIPTION
## Summary
- Node.js script that fetches random artworks from Harvard/Met/AIC museums
- Generates watercolor-style cards (1080x1350 post or 1080x1920 story) using canvas-based renderer
- Publishes to Instagram via Meta Graph API with Dropbox for temp image hosting
- GitHub Actions workflow for hourly automated posting
- Duplicate prevention via posted-history.json tracking
- Supports `--art=source:id` flag for posting specific artworks

## Usage
```bash
cd scripts/instagram-poster
npm install
node post.mjs              # random post
node post.mjs --story      # random story
node post.mjs --art=harvard:229060  # specific artwork
node post.mjs --dry-run    # generate locally without publishing
```

## Test plan
- [x] Dry run generates card locally
- [x] Dropbox upload + Instagram publish works end-to-end
- [x] Specific artwork posting via --art flag
- [ ] GitHub Actions workflow triggers on schedule
- [ ] Duplicate prevention skips previously posted artworks