### PR TITLE
feat: PWA, Art of the Day, detail skeleton & image zoom

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2587,25 +2587,58 @@
 }
 
 /* ============================================================
-   Art of the Day — banner at top of feed scroller
+   Art of the Day — floating icon + expandable banner
    ============================================================ */
+
+/* Small floating thumbnail button */
+.aotd-fab {
+  position: fixed;
+  top: calc(var(--feed-header-height) + 0.75rem);
+  right: 1.25rem;
+  z-index: 21;
+  width: 2.6rem;
+  height: 2.6rem;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  padding: 0;
+  background: var(--bg-primary);
+  cursor: pointer;
+  overflow: hidden;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+  animation: aotd-pulse 3s ease-in-out infinite;
+}
+
+.aotd-fab__thumb {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+@keyframes aotd-pulse {
+  0%, 100% { box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5); }
+  50% { box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5), 0 0 12px rgba(255, 255, 255, 0.15); }
+}
+
+/* Expanded banner — appears below the fab */
 .aotd-banner {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  margin: calc(var(--feed-header-height) + 0.5rem) 1rem 0;
+  position: fixed;
+  top: calc(var(--feed-header-height) + 3.5rem);
+  right: 1rem;
+  max-width: 20rem;
   padding: 0.65rem 0.75rem;
-  background: var(--glass-l2-bg);
+  background: rgba(20, 20, 20, 0.92);
   backdrop-filter: blur(var(--glass-l2-blur));
   -webkit-backdrop-filter: blur(var(--glass-l2-blur));
   border: 1px solid var(--glass-l2-border);
   border-radius: var(--radius-card);
   text-decoration: none;
   color: var(--text-primary);
-  animation: glass-reveal var(--duration-slow) var(--ease-glass);
-  position: relative;
-  z-index: 10;
-  scroll-snap-align: none;
+  animation: glass-reveal var(--duration-normal) var(--ease-glass);
+  z-index: 15;
 }
 
 .aotd-banner__thumb {

--- a/src/pages/FeedPage.tsx
+++ b/src/pages/FeedPage.tsx
@@ -37,7 +37,8 @@ export default function FeedPage() {
   } = useFeedQuery();
 
   const { data: aotd } = useArtOfTheDay();
-  const [aotdVisible, setAotdVisible] = useState(true);
+  const [aotdExpanded, setAotdExpanded] = useState(false);
+  const [aotdDismissed, setAotdDismissed] = useState(false);
 
   const artPieces = flattenFeedPages(data);
   const isInitialLoad = isLoading && !data;
@@ -55,7 +56,8 @@ export default function FeedPage() {
     e.preventDefault();
     e.stopPropagation();
     dismissArtOfTheDay();
-    setAotdVisible(false);
+    setAotdDismissed(true);
+    setAotdExpanded(false);
   };
 
   return (
@@ -75,31 +77,45 @@ export default function FeedPage() {
         </button>
       </header>
 
-      <main className="art-feed__scroller" ref={scrollerRef}>
-        {aotd && aotdVisible && (
-          <Link
-            to={`/artwork/${aotd.source}/${aotd.id}`}
-            className="aotd-banner"
-            aria-label={`Art of the Day: ${aotd.title}`}
+      {aotd && !aotdDismissed && (
+        <>
+          <button
+            type="button"
+            className="aotd-fab"
+            onClick={() => setAotdExpanded(!aotdExpanded)}
+            aria-label="Art of the Day"
           >
-            <img className="aotd-banner__thumb" src={aotd.imageUrl} alt="" />
-            <div className="aotd-banner__text">
-              <span className="aotd-banner__label">Art of the Day</span>
-              <span className="aotd-banner__title">{aotd.title}</span>
-              <span className="aotd-banner__artist">{aotd.artist} · {sourceName(aotd.source)}</span>
-            </div>
-            <button
-              type="button"
-              className="aotd-banner__close"
-              onClick={handleDismissAotd}
-              aria-label="Dismiss"
+            <img className="aotd-fab__thumb" src={aotd.imageUrl} alt="" />
+          </button>
+
+          {aotdExpanded && (
+            <Link
+              to={`/artwork/${aotd.source}/${aotd.id}`}
+              className="aotd-banner"
+              aria-label={`Art of the Day: ${aotd.title}`}
             >
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-                <path d="M18 6L6 18M6 6l12 12" />
-              </svg>
-            </button>
-          </Link>
-        )}
+              <img className="aotd-banner__thumb" src={aotd.imageUrl} alt="" />
+              <div className="aotd-banner__text">
+                <span className="aotd-banner__label">Art of the Day</span>
+                <span className="aotd-banner__title">{aotd.title}</span>
+                <span className="aotd-banner__artist">{aotd.artist} · {sourceName(aotd.source)}</span>
+              </div>
+              <button
+                type="button"
+                className="aotd-banner__close"
+                onClick={handleDismissAotd}
+                aria-label="Dismiss"
+              >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                  <path d="M18 6L6 18M6 6l12 12" />
+                </svg>
+              </button>
+            </Link>
+          )}
+        </>
+      )}
+
+      <main className="art-feed__scroller" ref={scrollerRef}>
         {artPieces.map((piece) => (
           <ArtCard key={`${piece.source}:${piece.id}`} art={piece} />
         ))}


### PR DESCRIPTION
## Summary
- **PWA support**: manifest.json, vite-plugin-pwa with workbox runtime caching (fonts + images), meta tags for install-to-home
- **Art of the Day**: small floating fab icon on feed (daily deterministic artwork pick), tap to expand glass banner with title/artist, tap banner to navigate to detail
- **Detail page skeleton**: shimmer loading skeleton replacing plain loading dots (hero image, palette, title, tags, metadata)
- **Image zoom**: fullscreen overlay on hero image tap with close button and native pinch-zoom support

## Test plan
- [ ] Verify PWA install prompt appears on mobile browsers
- [ ] Verify Art of the Day fab icon shows on feed, expands on tap, navigates on banner tap
- [ ] Verify dismiss (X) hides Art of the Day for the rest of the day
- [ ] Verify detail page shows shimmer skeleton while loading
- [ ] Verify tapping hero image opens fullscreen zoom overlay
- [ ] Verify zoom overlay closes on backdrop tap or X button

🤖 Generated with [Claude Code](https://claude.com/claude-code)