### PR TITLE
fix: exclude 403 sources from retry loop

### DIFF
--- a/scripts/instagram-poster/lib/art-fetchers.mjs
+++ b/scripts/instagram-poster/lib/art-fetchers.mjs
@@ -207,9 +207,13 @@ function rotateByTime(sources) {
   return [...sources.slice(offset), ...sources.slice(0, offset)];
 }
 
-export async function fetchRandomArtwork(historySet) {
-  // Filter to sources we can use (Harvard needs API key)
-  const available = SOURCES.filter((s) => !s.needsKey || HARVARD_API_KEY);
+export async function fetchRandomArtwork(historySet, excludeSources = new Set()) {
+  // Filter to sources we can use (Harvard needs API key) and not excluded
+  const available = SOURCES.filter((s) =>
+    (!s.needsKey || HARVARD_API_KEY) && !excludeSources.has(s.name.toLowerCase()),
+  );
+
+  if (available.length === 0) throw new Error("All art sources excluded or unavailable");
 
   // Try up to 10 times across all sources to find a non-duplicate
   for (let round = 0; round < 10; round++) {

--- a/scripts/instagram-poster/post.mjs
+++ b/scripts/instagram-poster/post.mjs
@@ -114,6 +114,7 @@ async function main() {
   let art;
   let pngBuffer;
   const MAX_RETRIES = 5;
+  const failedSources = new Set(); // Exclude sources whose images 403
 
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
     try {
@@ -126,7 +127,7 @@ async function main() {
           art = await fetchSeasonalArtwork(season, historySet);
         }
         if (!art) {
-          art = await fetchRandomArtwork(historySet);
+          art = await fetchRandomArtwork(historySet, failedSources);
         }
       }
 
@@ -139,6 +140,12 @@ async function main() {
       break;
     } catch (err) {
       console.warn(`Attempt ${attempt}/${MAX_RETRIES} failed: ${err.message}`);
+      // If image fetch returned 403, exclude this source on future retries
+      if (err.message.includes("403") && art?.source) {
+        const sourceName = art.source === "artic" ? "aic" : art.source;
+        failedSources.add(sourceName);
+        console.warn(`Excluding ${sourceName} (image 403) — remaining: ${SOURCES.filter((s) => !failedSources.has(s.name.toLowerCase())).map((s) => s.name).join(", ") || "none"}`);
+      }
       if (attempt === MAX_RETRIES || SPECIFIC_ART) throw err;
       art = null; // Reset so seasonal fallback can retry
     }


### PR DESCRIPTION
## Summary
- When an image fetch returns 403 (common with AIC IIIF), the source is excluded from subsequent retries
- Prevents the poster from hitting the same broken source 5 times and failing
- Falls back to Harvard/Met automatically when AIC is down

## Root cause
`rotateByTime()` deterministically picks the same starting source per hour. If AIC images are 403, all 5 retry attempts pick AIC again and fail.

## Test plan
- [ ] Trigger manual workflow run — should succeed by falling back to Harvard/Met