### PR TITLE
feat: seasonal post & reel on-demand

### DIFF
--- a/.github/workflows/instagram-post.yml
+++ b/.github/workflows/instagram-post.yml
@@ -16,6 +16,8 @@ on:
           - post
           - story
           - reel
+          - seasonal-post
+          - seasonal-reel
 
 jobs:
   post:
@@ -56,6 +58,10 @@ jobs:
             node post.mjs --story
           elif [ "$MODE" = "reel" ]; then
             node post.mjs --reel
+          elif [ "$MODE" = "seasonal-post" ]; then
+            node post.mjs --seasonal
+          elif [ "$MODE" = "seasonal-reel" ]; then
+            node post.mjs --seasonal --reel
           else
             node post.mjs
           fi

--- a/scripts/instagram-poster/post.mjs
+++ b/scripts/instagram-poster/post.mjs
@@ -10,6 +10,8 @@
  *   node post.mjs              # auto-cycles: post → post → reel → post …
  *   node post.mjs --story      # story (1080x1920, disappears in 24h)
  *   node post.mjs --reel       # reel (30s video with audio)
+ *   node post.mjs --seasonal   # force seasonal artwork (post)
+ *   node post.mjs --seasonal --reel  # force seasonal reel
  *   node post.mjs --dry-run    # generate card locally, skip Instagram publish
  *
  * Required env vars (see .env.example):
@@ -40,6 +42,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const args = process.argv.slice(2);
 const IS_STORY = args.includes("--story");
 const IS_REEL = args.includes("--reel");
+const IS_SEASONAL = args.includes("--seasonal");
 const DRY_RUN = args.includes("--dry-run");
 const ART_ARG = args.find((a) => a.startsWith("--art="));
 const SPECIFIC_ART = ART_ARG ? ART_ARG.replace("--art=", "") : null; // e.g. "harvard:229060"
@@ -120,6 +123,15 @@ async function main() {
     try {
       if (SPECIFIC_ART) {
         art = await fetchSpecificArtwork(SPECIFIC_ART);
+      } else if (IS_SEASONAL) {
+        // Force seasonal content (use active season or fall back to nearest)
+        const season = getActiveSeason() || { key: "on-demand", keywords: ["spring", "flowers", "landscape", "garden", "nature"] };
+        console.log(`Seasonal (forced): ${season.key}`);
+        art = await fetchSeasonalArtwork(season, historySet);
+        if (!art) {
+          console.warn("No seasonal artwork found — falling back to random");
+          art = await fetchRandomArtwork(historySet, failedSources);
+        }
       } else {
         // Check for seasonal content
         const season = shouldPostSeasonal(historyData);


### PR DESCRIPTION
## Summary
- New `--seasonal` CLI flag forces seasonal artwork (uses active season or default nature keywords)
- Combinable with `--reel` for seasonal reels: `node post.mjs --seasonal --reel`
- Workflow dispatch now has **seasonal-post** and **seasonal-reel** options

## Usage
```bash
node post.mjs --seasonal              # seasonal post
node post.mjs --seasonal --reel       # seasonal reel
node post.mjs --seasonal --dry-run    # test locally
```

## Test plan
- [ ] Trigger workflow with `seasonal-post` — should fetch season-themed art
- [ ] Trigger workflow with `seasonal-reel` — should create seasonal reel video