### PR TITLE
fix: SOURCES not defined in retry logging

### DIFF
--- a/scripts/instagram-poster/post.mjs
+++ b/scripts/instagram-poster/post.mjs
@@ -156,7 +156,7 @@ async function main() {
       if (err.message.includes("403") && art?.source) {
         const sourceName = art.source === "artic" ? "aic" : art.source;
         failedSources.add(sourceName);
-        console.warn(`Excluding ${sourceName} (image 403) — remaining: ${SOURCES.filter((s) => !failedSources.has(s.name.toLowerCase())).map((s) => s.name).join(", ") || "none"}`);
+        console.warn(`Excluding ${sourceName} (image 403) — ${failedSources.size} source(s) excluded`);
       }
       if (attempt === MAX_RETRIES || SPECIFIC_ART) throw err;
       art = null; // Reset so seasonal fallback can retry


### PR DESCRIPTION
## Summary
Fix `SOURCES is not defined` crash in post.mjs retry loop — was referencing a variable from art-fetchers.mjs without importing it.

## Root cause
The 403 exclusion logging line referenced `SOURCES` (defined in art-fetchers.mjs) directly in post.mjs. This crashed on the first 403 retry, preventing fallback to other sources.