### PR TITLE
fix: resolve 5 reliability issues in IG poster flow

### DIFF
--- a/scripts/instagram-poster/lib/art-fetchers.mjs
+++ b/scripts/instagram-poster/lib/art-fetchers.mjs
@@ -290,11 +290,14 @@ export function shouldPostSeasonal(historyData) {
   return season;
 }
 
-export async function fetchSeasonalArtwork(season, historySet) {
+export async function fetchSeasonalArtwork(season, historySet, excludeSources = new Set()) {
   const keyword = pick(season.keywords);
   console.log(`Seasonal (${season.key}): searching for "${keyword}"...`);
 
-  const available = SOURCES.filter((s) => !s.needsKey || HARVARD_API_KEY);
+  const available = SOURCES.filter((s) =>
+    (!s.needsKey || HARVARD_API_KEY) && !excludeSources.has(s.name.toLowerCase()),
+  );
+  if (available.length === 0) return null;
   const ordered = rotateByTime(available);
 
   for (const source of ordered) {

--- a/scripts/instagram-poster/lib/fetch.mjs
+++ b/scripts/instagram-poster/lib/fetch.mjs
@@ -3,14 +3,21 @@ export const IG_GRAPH = "https://graph.facebook.com/v21.0";
 export async function fetchJson(url, retries = 2) {
   for (let i = 0; i <= retries; i++) {
     const res = await fetch(url);
-    if (res.ok) return res.json();
+    if (res.ok) {
+      const text = await res.text();
+      try {
+        return JSON.parse(text);
+      } catch {
+        throw new Error(`Invalid JSON from ${new URL(url).hostname}: ${text.slice(0, 200)}`);
+      }
+    }
     if (res.status === 429 && i < retries) {
       const wait = (i + 1) * 2000;
       console.log(`Rate limited, retrying in ${wait / 1000}s...`);
       await new Promise((r) => setTimeout(r, wait));
       continue;
     }
-    throw new Error(`HTTP ${res.status}: ${url}`);
+    throw new Error(`HTTP ${res.status}: ${new URL(url).hostname}${new URL(url).pathname}`);
   }
 }
 

--- a/scripts/instagram-poster/lib/instagram-api.mjs
+++ b/scripts/instagram-poster/lib/instagram-api.mjs
@@ -113,11 +113,12 @@ export async function postFirstComment(token, mediaId, text) {
   }
 }
 
-export async function publishAutoStory(token, art) {
+export async function publishAutoStory(token, art, existingStoryBuffer = null) {
   try {
-    console.log("Rendering auto-story card...");
-    const storyBuffer = await renderStoryCard(art, art.imageUrl);
-    console.log(`Story card rendered: ${(storyBuffer.length / 1024).toFixed(0)} KB`);
+    const storyBuffer = existingStoryBuffer || await renderStoryCard(art, art.imageUrl);
+    if (!existingStoryBuffer) {
+      console.log(`Auto-story card rendered: ${(storyBuffer.length / 1024).toFixed(0)} KB`);
+    }
 
     const { url: storyUrl, path: storyPath, token: storyToken } = await uploadImage(storyBuffer);
     console.log("Publishing auto-story...");

--- a/scripts/instagram-poster/post.mjs
+++ b/scripts/instagram-poster/post.mjs
@@ -66,9 +66,11 @@ function pickAudioTrack() {
   return join(audioDir, pick(files));
 }
 
-async function createReelVideo(art) {
-  const cardBuffer = await renderStoryCard(art, art.imageUrl);
-  console.log(`Reel card rendered: ${(cardBuffer.length / 1024).toFixed(0)} KB`);
+async function createReelVideo(art, existingCardBuffer = null) {
+  const cardBuffer = existingCardBuffer || await renderStoryCard(art, art.imageUrl);
+  if (!existingCardBuffer) {
+    console.log(`Reel card rendered: ${(cardBuffer.length / 1024).toFixed(0)} KB`);
+  }
 
   const audioPath = pickAudioTrack();
   console.log(`Audio track: ${audioPath.split(/[\\/]/).pop()}`);
@@ -127,7 +129,7 @@ async function main() {
         // Force seasonal content (use active season or fall back to nearest)
         const season = getActiveSeason() || { key: "on-demand", keywords: ["spring", "flowers", "landscape", "garden", "nature"] };
         console.log(`Seasonal (forced): ${season.key}`);
-        art = await fetchSeasonalArtwork(season, historySet);
+        art = await fetchSeasonalArtwork(season, historySet, failedSources);
         if (!art) {
           console.warn("No seasonal artwork found — falling back to random");
           art = await fetchRandomArtwork(historySet, failedSources);
@@ -136,7 +138,7 @@ async function main() {
         // Check for seasonal content
         const season = shouldPostSeasonal(historyData);
         if (season) {
-          art = await fetchSeasonalArtwork(season, historySet);
+          art = await fetchSeasonalArtwork(season, historySet, failedSources);
         }
         if (!art) {
           art = await fetchRandomArtwork(historySet, failedSources);
@@ -172,7 +174,7 @@ async function main() {
     if (mode === "reel") {
       try {
         console.log("\nCreating reel video (dry-run)...");
-        const videoBuffer = await createReelVideo(art);
+        const videoBuffer = await createReelVideo(art, pngBuffer);
         writeFileSync(`${basename}.mp4`, videoBuffer);
         console.log(`Saved to ${basename}.mp4 (${(videoBuffer.length / 1024 / 1024).toFixed(1)} MB)`);
       } catch (err) {
@@ -198,7 +200,7 @@ async function main() {
   // 6. Publish based on mode
   if (mode === "reel") {
     console.log("Creating reel video...");
-    const videoBuffer = await createReelVideo(art);
+    const videoBuffer = await createReelVideo(art, pngBuffer);
     console.log("Publishing reel...");
     mediaId = await publishReel(token, videoBuffer, caption);
   } else if (mode === "story") {
@@ -224,12 +226,14 @@ async function main() {
   }
 
   // 8. Publish auto-story (not if already a story)
+  //    Reels already have a story-sized card (1080x1920) — reuse it
   if (mode !== "story") {
-    await publishAutoStory(token, art);
+    const storyCard = mode === "reel" ? pngBuffer : null;
+    await publishAutoStory(token, art, storyCard);
   }
 
   // 9. Update history
-  const wasSeasonal = getActiveSeason() !== null && SPECIFIC_ART === null;
+  const wasSeasonal = (IS_SEASONAL || getActiveSeason() !== null) && SPECIFIC_ART === null;
   historyData.posted.push(artKey(art));
   historyData.postsSinceLastSeasonal = wasSeasonal ? 0 : historyData.postsSinceLastSeasonal + 1;
   historyData.runIndex = (historyData.runIndex + 1) % MODE_CYCLE.length;


### PR DESCRIPTION
## Summary
- **Reel double-render** — `createReelVideo` now reuses the already-rendered card buffer instead of fetching the image again
- **Seasonal ignores failedSources** — `fetchSeasonalArtwork` now accepts and respects `excludeSources` to skip 403'd sources
- **wasSeasonal on-demand** — `IS_SEASONAL` flag now correctly resets the seasonal cooldown counter
- **fetchJson non-JSON crash** — safe JSON parse with readable error messages; error URLs no longer leak API keys
- **Auto-story triple-render** — `publishAutoStory` accepts pre-rendered buffer; reels reuse story-sized card

## Test plan
- [x] `node post.mjs --seasonal --reel --dry-run` passes locally
- [ ] Trigger manual workflow run with `seasonal-reel`